### PR TITLE
revert enforcing SSE-KMS on CloudFront access logs buckets

### DIFF
--- a/state/s3.yaml
+++ b/state/s3.yaml
@@ -72,7 +72,7 @@ Parameters:
     Description: 'Access policy of the bucket.'
     Type: String
     Default: Private
-    AllowedValues: [Private, PublicRead, PublicWrite, PublicReadAndWrite, CloudFrontRead, CloudFrontAccessLogWrite, CloudFrontAccessLogWriteEncrypted, ElbAccessLogWrite, ElbAccessLogWriteEncrypted, S3AccessLogWrite, ConfigWrite, CloudTrailWrite, VpcEndpointRead, FlowLogWrite]
+    AllowedValues: [Private, PublicRead, PublicWrite, PublicReadAndWrite, CloudFrontRead, CloudFrontAccessLogWrite, ElbAccessLogWrite, ElbAccessLogWriteEncrypted, S3AccessLogWrite, ConfigWrite, CloudTrailWrite, VpcEndpointRead, FlowLogWrite]
   Versioning:
     Description: 'Enable versioning to keep a backup if objects change.'
     Type: String
@@ -137,8 +137,7 @@ Conditions:
   HasPublicReadAccess: !Or [!Equals [!Ref Access, PublicRead], !Equals [!Ref Access, PublicReadAndWrite]]
   HasPublicWriteAccess: !Or [!Equals [!Ref Access, PublicWrite], !Equals [!Ref Access, PublicReadAndWrite]]
   HasCloudFrontReadAccess: !Equals [!Ref Access, CloudFrontRead]
-  HasCloudFrontAccessLogWrite: !Or [!Equals [!Ref Access, CloudFrontAccessLogWrite], !Equals [!Ref Access, CloudFrontAccessLogWriteEncrypted]]
-  HasCloudFrontAccessLogWriteEncrypted: !Equals [!Ref Access, CloudFrontAccessLogWriteEncrypted]
+  HasCloudFrontAccessLogWrite: !Equals [!Ref Access, CloudFrontAccessLogWrite]
   HasElbAccessLogWriteAccess: !Or [!Equals [!Ref Access, ElbAccessLogWrite], !Equals [!Ref Access, ElbAccessLogWriteEncrypted]]
   # The only server-side encryption option that's supported is Amazon S3-managed keys (SSE-S3).
   HasElbAccessLogWriteEncrypted: !Equals [!Ref Access, ElbAccessLogWriteEncrypted]
@@ -308,19 +307,6 @@ Resources:
             Condition:
               StringNotEquals:
                 's3:x-amz-server-side-encryption': 'AES256' # https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingServerSideEncryption.html
-          - !Ref 'AWS::NoValue'
-        - !If
-          - HasCloudFrontAccessLogWriteEncrypted
-          - Principal: '*'
-            Action: 's3:PutObject*'
-            Effect: Deny
-            Resource: !Sub '${Bucket.Arn}/*'
-            Condition:
-              StringNotEquals:
-                's3:x-amz-server-side-encryption':
-                - 'AES256'
-                - 'aws:kms'
-                's3:x-amz-server-side-encryption-aws-kms-key-id': {'Fn::ImportValue': !Sub '${ParentKmsKeyStack}-KeyArn'}
           - !Ref 'AWS::NoValue'
         - !If
           - HasConfigWriteAccess


### PR DESCRIPTION
CloudFront doesn't appear to (currently) set SSE/KMS parameters on its access log write requests to S3, so a deny policy prevents logs from being written, even though encryption would happen regardless.

**(Override all values in parentheses)**

(Run `yamllint folder/template.yaml`, `cfn-lint -i E1019 E3002 E2520 -t folder/template.yaml`, and `aws cloudformation validate-template --template-body file://folder/template.yaml` before you open a PR)

(Do not include multiple changes in one PR. Open additional PRs instead.)

---

(describe your change here)
