### PR TITLE
patch: Fix cfn-lint error E3014 for static-website template.

### DIFF
--- a/static-website/static-website.yaml
+++ b/static-website/static-website.yaml
@@ -272,9 +272,12 @@ Resources:
           S3OriginConfig:
             OriginAccessIdentity: !Sub 'origin-access-identity/cloudfront/${CloudFrontOriginAccessIdentity}'
         PriceClass: 'PriceClass_All'
-        ViewerCertificate:
-          AcmCertificateArn: !If [HasCreateAcmCertificate, !Ref Certificate, !If [HasAcmCertificateArn, !Ref ExistingCertificate, !Ref 'AWS::NoValue']]
-          IamCertificateId: !If [HasIamCertificateId, !Ref ExistingCertificate, !Ref 'AWS::NoValue']
+        ViewerCertificate: !If
+        - HasIamCertificateId # Check if IamCertificateId is chosen
+        - IamCertificateId: !Ref ExistingCertificate
+          MinimumProtocolVersion: 'TLSv1.2_2019'
+          SslSupportMethod: 'sni-only'
+        - AcmCertificateArn: !If [HasAcmCertificateArn, !Ref ExistingCertificate, !Ref Certificate]
           MinimumProtocolVersion: 'TLSv1.2_2019'
           SslSupportMethod: 'sni-only'
         WebACLId: !If


### PR DESCRIPTION
**(Override all values in parentheses)**

(Run `yamllint folder/template.yaml`, `cfn-lint -i E1019 E3002 E2520 -t folder/template.yaml`, and `aws cloudformation validate-template --template-body file://folder/template.yaml` before you open a PR)

(Do not include multiple changes in one PR. Open additional PRs instead.)

---

This fixes the following cfn-lint errors for the static-website template:
```
E3014 Only one of ['AcmCertificateArn', 'CloudFrontDefaultCertificate', 'IamCertificateId'] is a required property
base/aws/aws-cf-templates/static-website/static-website.yaml:276:11

E3014 Only one of ['AcmCertificateArn', 'CloudFrontDefaultCertificate', 'IamCertificateId'] is a required property
base/aws/aws-cf-templates/static-website/static-website.yaml:277:11
```

This change ensures that the correct property is used depending on the `CertificateType` parameter option chosen by the user.